### PR TITLE
ci: remove Go 1.24.x from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.24.x"
           - "1.25.x"
 
     steps:


### PR DESCRIPTION
## Summary
- remove Go `1.24.x` from the CI matrix in `.github/workflows/ci.yml`
- keep CI aligned with the current module target (`go 1.25.0`)

## Test plan
- [x] Confirm workflow YAML is valid after matrix change
- [x] Verify GitHub Actions runs successfully on the PR