### PR TITLE
Potential fix for code scanning alert no. 1: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -145,6 +145,7 @@ func ClearSessionCookie(w http.ResponseWriter) {
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
+		Secure:   true,
 		MaxAge:   -1,
 	})
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ferez96/Progames/security/code-scanning/1](https://github.com/ferez96/Progames/security/code-scanning/1)

Set the `Secure` attribute explicitly in `ClearSessionCookie` when constructing the cookie passed to `http.SetCookie`.

Best fix here (without broader behavioral changes) is to update `internal/auth/auth.go` in `ClearSessionCookie` and add:

- `Secure: true,`

This ensures the cookie explicitly includes the `Secure` flag instead of relying on the insecure default. No imports, helper methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
